### PR TITLE
project builds as a DLL that call be called by run32dll.exe

### DIFF
--- a/src/AudioSwitcher.sln
+++ b/src/AudioSwitcher.sln
@@ -1,20 +1,26 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30324.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AudioSwitcher", "AudioSwitcher\AudioSwitcher.csproj", "{8F82476F-30DC-47A5-80A0-AB8437E4EEA5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8F82476F-30DC-47A5-80A0-AB8437E4EEA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8F82476F-30DC-47A5-80A0-AB8437E4EEA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F82476F-30DC-47A5-80A0-AB8437E4EEA5}.Debug|x64.ActiveCfg = Debug|x64
+		{8F82476F-30DC-47A5-80A0-AB8437E4EEA5}.Debug|x64.Build.0 = Debug|x64
 		{8F82476F-30DC-47A5-80A0-AB8437E4EEA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8F82476F-30DC-47A5-80A0-AB8437E4EEA5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F82476F-30DC-47A5-80A0-AB8437E4EEA5}.Release|x64.ActiveCfg = Release|x64
+		{8F82476F-30DC-47A5-80A0-AB8437E4EEA5}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/AudioSwitcher/AudioSwitcher.csproj
+++ b/src/AudioSwitcher/AudioSwitcher.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{8F82476F-30DC-47A5-80A0-AB8437E4EEA5}</ProjectGuid>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AudioSwitcher</RootNamespace>
     <AssemblyName>AudioSwitcher</AssemblyName>
@@ -20,7 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -38,29 +38,46 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
-    <StartupObject>AudioSwitcher.Program</StartupObject>
+    <StartupObject>
+    </StartupObject>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Resources\Images\Executable.ico</ApplicationIcon>
   </PropertyGroup>
-  <PropertyGroup>
-    <ApplicationManifest>Properties\App.manifest</ApplicationManifest>
+  <PropertyGroup />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="RGiesecke.DllExport.Metadata">
+      <HintPath>..\packages\UnmanagedExports.1.2.6\lib\net\RGiesecke.DllExport.Metadata.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Audio\Interop\MMAudio\ConnectorType.cs" />
-    <Compile Include="Audio\Interop\MMAudio\DataFlow.cs" />
-    <Compile Include="Audio\Interop\MMAudio\IConnector.cs" />
-    <Compile Include="Audio\Interop\MMAudio\IDeviceTopology.cs" />
-    <Compile Include="Audio\Interop\MMAudio\IKsControl.cs" />
-    <Compile Include="Audio\Interop\MMAudio\IPartsList.cs" />
-    <Compile Include="Audio\Interop\MMAudio\IPart.cs" />
-    <Compile Include="Audio\Interop\MMAudio\KSMethod.cs" />
     <Compile Include="ComponentModel\IPriorityMetadata.cs" />
     <Compile Include="Presentation\IPresenter.cs" />
     <Compile Include="Presentation\NonModalPresenter.cs" />
@@ -193,6 +210,7 @@
     <Compile Include="Win32\RegistryKeyExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="Properties\App.config" />
     <None Include="Properties\App.manifest" />
     <None Include="Properties\Settings.settings">
@@ -224,4 +242,5 @@
     <Folder Include="UI\Views\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="../packages/UnmanagedExports.1.2.6/tools/RGiesecke.DllExport.targets" Condition="Exists('../packages/UnmanagedExports.1.2.6/tools/RGiesecke.DllExport.targets')" />
 </Project>

--- a/src/AudioSwitcher/Program.cs
+++ b/src/AudioSwitcher/Program.cs
@@ -4,11 +4,13 @@
 using System;
 using System.ComponentModel.Composition.Hosting;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using AudioSwitcher.ApplicationModel;
+using RGiesecke.DllExport;
 
 namespace AudioSwitcher
 {
-    internal class Program
+    internal static class Program
     {
         [STAThread]
         public static void Main()
@@ -20,6 +22,16 @@ namespace AudioSwitcher
                 IApplication application = container.GetExportedValue<IApplication>();
                 application.Start();
             }
+        }
+
+        [DllExport]
+        public static void RunInTaskBar(
+            [In] IntPtr hwnd,
+            [In] IntPtr ModuleHandle,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string CmdLineBuffer,
+            int nCmdShow)
+        {
+            Main();
         }
     }
 }

--- a/src/AudioSwitcher/UI/Commands/RunAtWindowsStartupCommand.cs
+++ b/src/AudioSwitcher/UI/Commands/RunAtWindowsStartupCommand.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel.Composition;
 using System.IO;
+using System.Reflection;
 using System.Windows.Forms;
 using AudioSwitcher.Presentation.CommandModel;
 using AudioSwitcher.Win32;
@@ -14,8 +15,12 @@ namespace AudioSwitcher.UI.Commands
     [Command(CommandId.RunAtWindowsStartup)]
     internal class RunAtWindowsStartupCommand : Command
     {
-        private readonly static string RunAsWindowsStartupValue = '"' + Application.ExecutablePath + "\" -silent";
-        private readonly static string RunAtWindowsStartupValueName = Path.GetFileNameWithoutExtension(Application.ExecutablePath);
+        private static readonly FileInfo AssemblyFileInfo =  new FileInfo(Assembly.GetExecutingAssembly().Location);
+        private static readonly string AssemblyName = Assembly.GetExecutingAssembly().GetName().Name;
+        private readonly static string RunAsWindowsStartupValue = Application.ExecutablePath.EndsWith("rundll32.exe")
+            ? string.Format("rundll32.exe \"{0}\" RunInTaskBar", AssemblyFileInfo.FullName)
+            : string.Format("\"{0}\"", AssemblyFileInfo.FullName);
+        private readonly static string RunAtWindowsStartupValueName = AssemblyName;
 
         [ImportingConstructor]
         public RunAtWindowsStartupCommand()

--- a/src/AudioSwitcher/packages.config
+++ b/src/AudioSwitcher/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="UnmanagedExports" version="1.2.6" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
For Issue 19. Unfortunately we can't build this as AnyCPU for the unmanaged exports to work. It probably makes sense to just use the 32 bit dlls.