### PR TITLE
Add an installer based on Squirrel.Windows

### DIFF
--- a/CreateInstaller.ps1
+++ b/CreateInstaller.ps1
@@ -5,7 +5,8 @@ if ($DTE -eq $null) {
   exit 1
 }
 
-mkdir -p $tempDirectoryName
+mkdir -Path $tempDirectoryName
 rm -r -fo "$tempDirectoryName\*.nupkg"
-NuGet pack .\src\AudioSwitcher.sln -OutputDirectory "$tempDirectoryName"
-ls "$tempDirectoryName\*.nupkg" | %{Squirrel --releasify $_ -p .\packages}
+NuGet pack .\src\AudioSwitcher\AudioSwitcher.csproj -OutputDirectory "$tempDirectoryName" -Prop Configuration=Release
+ls "$tempDirectoryName\*.nupkg" | %{Squirrel --releasify $_ -p .\src\packages -r .\Releases}
+rm -r -fo "$tempDirectoryName"

--- a/CreateInstaller.ps1
+++ b/CreateInstaller.ps1
@@ -1,0 +1,11 @@
+$tempDirectoryName = '.\__squirrel_temp__'
+
+if ($DTE -eq $null) {
+  echo "Run this from the NuGet Package Console inside VS"
+  exit 1
+}
+
+mkdir -p $tempDirectoryName
+rm -r -fo "$tempDirectoryName\*.nupkg"
+NuGet pack .\src\AudioSwitcher.sln -OutputDirectory "$tempDirectoryName"
+ls "$tempDirectoryName\*.nupkg" | %{Squirrel --releasify $_ -p .\packages}

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NuGet.CommandLine" version="2.8.3" />
+</packages>

--- a/src/AudioSwitcher.sln
+++ b/src/AudioSwitcher.sln
@@ -1,9 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30324.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AudioSwitcher", "AudioSwitcher\AudioSwitcher.csproj", "{8F82476F-30DC-47A5-80A0-AB8437E4EEA5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{44D8C18F-D4F9-4248-8AB7-3F4A8CBA3517}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\packages.config = .nuget\packages.config
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/AudioSwitcher/AudioSwitcher.csproj
+++ b/src/AudioSwitcher/AudioSwitcher.csproj
@@ -47,6 +47,42 @@
     <ApplicationManifest>Properties\App.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DeltaCompressionDotNet">
+      <HintPath>..\packages\DeltaCompressionDotNet.1.0.0\lib\net45\DeltaCompressionDotNet.dll</HintPath>
+    </Reference>
+    <Reference Include="DeltaCompressionDotNet.MsDelta">
+      <HintPath>..\packages\DeltaCompressionDotNet.1.0.0\lib\net45\DeltaCompressionDotNet.MsDelta.dll</HintPath>
+    </Reference>
+    <Reference Include="DeltaCompressionDotNet.PatchApi">
+      <HintPath>..\packages\DeltaCompressionDotNet.1.0.0\lib\net45\DeltaCompressionDotNet.PatchApi.dll</HintPath>
+    </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib">
+      <HintPath>..\packages\squirrel.windows.0.8.0\lib\Net45\ICSharpCode.SharpZipLib.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Web.XmlTransform">
+      <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil">
+      <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb">
+      <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb">
+      <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks">
+      <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Core">
+      <HintPath>..\packages\NuGet.Core.2.8.3\lib\net40-Client\NuGet.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Splat">
+      <HintPath>..\packages\Splat.1.5.1\lib\Net45\Splat.dll</HintPath>
+    </Reference>
+    <Reference Include="Squirrel">
+      <HintPath>..\packages\squirrel.windows.0.8.0\lib\Net45\Squirrel.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Drawing" />
@@ -186,6 +222,7 @@
     <Compile Include="Win32\RegistryKeyExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="Properties\App.config" />
     <None Include="Properties\App.manifest" />
     <None Include="Properties\Settings.settings">

--- a/src/AudioSwitcher/Properties/AssemblyInfo.cs
+++ b/src/AudioSwitcher/Properties/AssemblyInfo.cs
@@ -6,9 +6,9 @@ using System.Resources;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("AudioSwitcher")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("App that lets you easily switch Windows audio devices")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("David Kean")]
 [assembly: AssemblyProduct("AudioSwitcher")]
 [assembly: AssemblyCopyright("Copyright (c) David Kean")]
 [assembly: AssemblyTrademark("")]

--- a/src/AudioSwitcher/packages.config
+++ b/src/AudioSwitcher/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="DeltaCompressionDotNet" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
+  <package id="Mono.Cecil" version="0.9.5.4" targetFramework="net45" />
+  <package id="NuGet.Core" version="2.8.3" targetFramework="net45" />
+  <package id="Splat" version="1.5.1" targetFramework="net45" />
+  <package id="squirrel.windows" version="0.8.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
This PR is the initial start of an installer for AudioSwitcher, here's how to use it:

1. Build the project in Release mode (msbuild's not in PATH in the Package Manager Console??)
1. In the Package Manager Console, run `.\CreateInstaller.ps1`
1. Open up the Releases folder

Take that folder, upload it verbatim to some sort of S3'ish thing that will host files, and you've got an update server. 

Some cool things to add in the future (I didn't want to do anything because I assumed you'd want to set up your own update folder):

* Actually running updates in the app using the Squirrel library
* Creating a proper nuspec file so that you can make the installer way smaller (it's almost certainly including files that aren't needed)
* Displaying What's New / Release Notes / etc